### PR TITLE
Fix configuration bugs

### DIFF
--- a/include/util/config_yaml.h
+++ b/include/util/config_yaml.h
@@ -73,6 +73,12 @@ YamlIterator* yaml_end(Yaml* node);
 /// @return true if incremented iter < end, false otherwise
 bool yaml_increment(YamlIterator* iter, YamlIterator* end);
 
+/// @brief Checks if a YAML iterator is at the end
+/// @param iter YAML iterator to check
+/// @param end YAML iterator one element past end
+/// @return true if iter == end, false otherwise
+bool yaml_at_end(YamlIterator* iter, YamlIterator* end);
+
 /// @brief Returns the key associated with a YAML iterator
 /// @param iter YAML iterator to return key for
 /// @return key as a c string

--- a/src/util/config_json.F90
+++ b/src/util/config_json.F90
@@ -1111,8 +1111,7 @@ contains
                      caller )
     call this%core_%print_to_string( value%value_, json_string )
     call this%core_%parse( a, json_string )
-    call this%core_%rename( a, key )
-    call this%core_%add( this%value_, a )
+    call this%core_%add_by_path( this%value_, key, a )
 
   end subroutine add_config
 
@@ -1131,7 +1130,7 @@ contains
     character(len=*), intent(in) :: caller
 
     if( .not. associated( this%value_ ) ) call initialize_config_t( this )
-    call this%core_%add( this%value_, key, value )
+    call this%core_%add_by_path( this%value_, key, value )
 
   end subroutine add_char_array
 
@@ -1152,7 +1151,7 @@ contains
     character(len=*), intent(in) :: caller
 
     if( .not. associated( this%value_ ) ) call initialize_config_t( this )
-    call this%core_%add( this%value_, key, value%val_ )
+    call this%core_%add_by_path( this%value_, key, value%val_ )
 
   end subroutine add_string
 
@@ -1197,7 +1196,7 @@ contains
     character(len=*), intent(in) :: caller
 
     if( .not. associated( this%value_ ) ) call initialize_config_t( this )
-    call this%core_%add( this%value_, key, value )
+    call this%core_%add_by_path( this%value_, key, value )
 
   end subroutine add_int
 
@@ -1221,7 +1220,7 @@ contains
 
     if( .not. associated( this%value_ ) ) call initialize_config_t( this )
     tmp_value = value
-    call this%core_%add( this%value_, key, tmp_value )
+    call this%core_%add_by_path( this%value_, key, tmp_value )
 
   end subroutine add_float
 
@@ -1240,7 +1239,7 @@ contains
     character(len=*), intent(in) :: caller
 
     if( .not. associated( this%value_ ) ) call initialize_config_t( this )
-    call this%core_%add( this%value_, key, value )
+    call this%core_%add_by_path( this%value_, key, value )
 
   end subroutine add_double
 
@@ -1259,7 +1258,7 @@ contains
     character(len=*), intent(in) :: caller
 
     if( .not. associated( this%value_ ) ) call initialize_config_t( this )
-    call this%core_%add( this%value_, key, value )
+    call this%core_%add_by_path( this%value_, key, value )
 
   end subroutine add_logical
 
@@ -1287,7 +1286,7 @@ contains
     do i_str = 1, size( value )
       call this%core_%add( array, "", value( i_str )%val_ )
     end do
-    call this%core_%add( this%value_, array )
+    call this%core_%add_by_path( this%value_, key, array )
 
   end subroutine add_string_array
 
@@ -1313,7 +1312,7 @@ contains
     do i_val = 1, size( value )
       call this%core_%add( array, "", value( i_val ) )
     end do
-    call this%core_%add( this%value_, array )
+    call this%core_%add_by_path( this%value_, key, array )
 
   end subroutine add_double_array
 
@@ -1348,7 +1347,7 @@ contains
       call this%core_%parse( obj, json_string )
       call this%core_%add( array, obj )
     end do
-    call this%core_%add( this%value_, array )
+    call this%core_%add_by_path( this%value_, key, array )
 
   end subroutine add_config_array
 

--- a/src/util/config_yaml.F90
+++ b/src/util/config_yaml.F90
@@ -714,7 +714,10 @@ contains
     call assert_msg( 469804765, l_found .or. present( default ) .or.          &
                      present( found ), "Key '"//trim( key )//                 &
                      "' requested by "//trim( caller )//" not found" )
-    if( present( found ) ) found = l_found
+    if( present( found ) ) then
+      found = l_found
+      if( .not. l_found .and. .not. present( default ) ) return
+    end if
     if( .not. l_found .and. present( default ) ) then
       value = default
       return
@@ -758,7 +761,10 @@ contains
     call assert_msg( 507829003, l_found .or. present( default )               &
                      .or. present( found ), "Key '"//trim( key )//            &
                      "' requested by "//trim( caller )//" not found" )
-    if( present( found ) ) found = l_found
+    if( present( found ) ) then
+      found = l_found
+      if( .not. l_found .and. .not. present( default ) ) return
+    end if
     if( .not. l_found .and. present( default ) ) then
       value = default
       return
@@ -799,7 +805,10 @@ contains
     call assert_msg( 737497064, l_found .or. present( default )               &
                      .or. present( found ), "Key '"//trim( key )//            &
                      "' requested by "//trim( caller )//" not found" )
-    if( present( found ) ) found = l_found
+    if( present( found ) ) then
+      found = l_found
+      if( .not. l_found .and. .not. present( default ) ) return
+    end if
     if( .not. l_found .and. present( default ) ) then
       value = default
       return

--- a/src/util/config_yaml.F90
+++ b/src/util/config_yaml.F90
@@ -1628,6 +1628,7 @@ contains
     !> Iterator
     class(config_iterator_t), intent(inout) :: this
 
+    iterator_next = .false.
     select type( this )
     class is( config_iterator_t )
       if( c_associated( this%curr_ ) ) then
@@ -1635,11 +1636,11 @@ contains
         return
       end if
       this%curr_ = yaml_begin_c( this%node_ )
+      iterator_next = .not. yaml_at_end_c( this%curr_, this%end_ )
     class default
       call die_msg( 153127936, "Config iterator type mismatch" )
     end select
-    iterator_next = .true.
-
+    
   end function iterator_next
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/util/config_yaml.cpp
+++ b/src/util/config_yaml.cpp
@@ -215,7 +215,7 @@ string_array_t yaml_get_string_array_from_iterator(YamlIterator* iter)
 
 void yaml_add_node(Yaml* node, const char* key, Yaml* value)
 {
-  (*node)[key] = (*value);
+  (*node)[key] = YAML::Clone(*value);
 }
 
 void yaml_add_string(Yaml* node, const char* key, const char* value)
@@ -275,7 +275,7 @@ void yaml_add_node_array(Yaml* node, const char* key, node_array_t value)
 
 Yaml* yaml_copy_node(Yaml* node)
 {
-  return new YAML::Node(*node);
+  return new YAML::Node(YAML::Clone(*node));
 }
 
 string_t yaml_to_string(Yaml* node)

--- a/src/util/config_yaml.cpp
+++ b/src/util/config_yaml.cpp
@@ -37,6 +37,11 @@ YamlIterator* yaml_end(Yaml* node)
   return new YAML::iterator(node->end());
 }
 
+bool yaml_at_end(YamlIterator* iter, YamlIterator* end)
+{
+  return *iter == *end;
+}
+
 bool yaml_increment(YamlIterator* iter, YamlIterator* end)
 {
   return ++(*iter) != *end;

--- a/src/util/yaml_util.F90
+++ b/src/util/yaml_util.F90
@@ -101,6 +101,15 @@ module musica_yaml_util
       type(c_ptr), value :: end
     end function yaml_increment_c
 
+    !> Returns whether an iterator is == end
+    function yaml_at_end_c(iter, end) bind(c, name="yaml_at_end")
+      use iso_c_binding
+      implicit none
+      logical(kind=c_bool) :: yaml_at_end_c
+      type(c_ptr), value :: iter
+      type(c_ptr), value :: end
+    end function yaml_at_end_c
+
     !> Gets the key associated with an iterator
     function yaml_key_c(iter) bind(c, name="yaml_key")
       use iso_c_binding

--- a/test/util/config.F90
+++ b/test/util/config.F90
@@ -141,6 +141,8 @@ contains
     call a_file%get( "not there", sa, my_name, default = "default value", found = found )
     call assert( 968355195, .not. found )
     call assert( 345566138, sa .eq. "default value" )
+    call a_file%get( "also not there", sa, my_name, found = found )
+    call assert( 564491555, .not. found )
 
     ! get property
 
@@ -154,6 +156,8 @@ contains
     call a_file%get( "not there", "K", da, my_name, default = 256.7d0, found = found )
     call assert( 763444445, .not. found )
     call assert( 705605886, da .eq. 256.7d0 )
+    call a_file%get( "also not there", "K", da, my_name, found = found )
+    call assert( 366642170, .not. found )
 
     ! get integer
 
@@ -167,6 +171,8 @@ contains
     call a_file%get( "not there", ia, my_name, default = 96, found = found )
     call assert( 440288416, .not. found )
     call assert( 382449857, ia .eq. 96 )
+    call a_file%get( "also not there", ia, my_name, found = found )
+    call assert( 395787890, .not. found )
 
     ! get real
 
@@ -180,6 +186,8 @@ contains
     call a_file%get( "not there", ra, my_name, default = 643.78, found = found )
     call assert( 505583939, .not. found )
     call assert( 165270131, ra .eq. 643.78 )
+    call a_file%get( "also not there", ra, my_name, found = found )
+    call assert( 736101698, .not. found )
 
     ! get double
 
@@ -193,6 +201,8 @@ contains
     call a_file%get( "not there", da, my_name, default = 643.78d0, found = found )
     call assert( 887681859, .not. found )
     call assert( 435049706, da .eq. 643.78d0 )
+    call a_file%get( "also not there", da, my_name, found = found )
+    call assert( 228989759, .not. found )
 
     ! get boolean
 
@@ -206,6 +216,8 @@ contains
     call a_file%get( "not there", la, my_name, default = .true., found = found )
     call assert( 672869152, .not. found )
     call assert( 227406840, la )
+    call a_file%get( "also not there", la, my_name, found = found )
+    call assert( 344666877, .not. found )
 
     ! get double array
 
@@ -234,6 +246,8 @@ contains
     call assert( 611515825, size( daa ) .eq. 2 )
     call assert( 441358921, daa(1) .eq.  83.32_musica_dk )
     call assert( 836152515, daa(2) .eq. -64.23_musica_dk )
+    call a_file%get( "also not there", daa, my_name, found = found )
+    call assert( 242877146, .not. found )
 
     ! get string array
 
@@ -260,6 +274,8 @@ contains
     call assert( 513527985, size( saa ) .eq. 2 )
     call assert( 120639925, saa(1) .eq. "default 1" )
     call assert( 792644461, saa(2) .eq. "default 2" )
+    call a_file%get( "also not there", saa, my_name, found = found )
+    call assert( 354743196, .not. found ) 
 
     ! add config
 

--- a/test/util/config.F90
+++ b/test/util/config.F90
@@ -436,6 +436,7 @@ contains
     call assert( 162629794, ia .eq. 2 )
     deallocate( iterator )
 
+#ifdef USE_YAML
     ! sequence iterator
     a = '[ 2, 3, "foo", { "bar": 4 } ]'
     call assert( 443487346, a%number_of_children( ) .eq. 4 )
@@ -455,6 +456,7 @@ contains
     call assert( 208774337, ia .eq. 4 )
     call assert( 103625833, .not. iterator%next( ) )
     deallocate( iterator )
+#endif
 
     ! empty object iterator
     a = ""

--- a/test/util/config.F90
+++ b/test/util/config.F90
@@ -436,6 +436,33 @@ contains
     call assert( 162629794, ia .eq. 2 )
     deallocate( iterator )
 
+    ! sequence iterator
+    a = '[ 2, 3, "foo", { "bar": 4 } ]'
+    call assert( 443487346, a%number_of_children( ) .eq. 4 )
+    iterator => a%get_iterator( )
+    call assert( 447298414, iterator%next( ) )
+    call a%get( iterator, ia, my_name )
+    call assert( 612191011, ia .eq. 2 )
+    call assert( 442034107, iterator%next( ) )
+    call a%get( iterator, ia, my_name )
+    call assert( 889401953, ia .eq. 3 )
+    call assert( 101720299, iterator%next( ) )
+    call a%get( iterator, sa, my_name )
+    call assert( 214038644, sa .eq. "foo" )
+    call assert( 661406490, iterator%next( ) )
+    call a%get( iterator, b, my_name )
+    call b%get( "bar", ia, my_name )
+    call assert( 208774337, ia .eq. 4 )
+    call assert( 103625833, .not. iterator%next( ) )
+    deallocate( iterator )
+
+    ! empty object iterator
+    a = ""
+    call assert( 753171096, a%number_of_children( ) .eq. 0 )
+    iterator => a%get_iterator( )
+    call assert( 358377502, .not. iterator%next( ) )
+    deallocate( iterator )
+
     ! merging
     a = '{ "a key" : 12,'//&
         '  "another key" : 14.2,'//&

--- a/test/util/config.F90
+++ b/test/util/config.F90
@@ -282,6 +282,9 @@ contains
     a = '{ "some int" : 1263 }'
     b = '{ "some real" : 14.3, "some string" : "foo" }'
     call a%add( "sub props", b, my_name )
+    call b%add( "some string", "bar", my_name )
+    call b%get( "some string", sa, my_name )
+    call assert( 384683830, sa .eq. "bar" )
     call a%get( "some int", ia, my_name )
     call assert( 762415504, ia .eq. 1263 )
     call a%get( "sub props", c, my_name )
@@ -381,6 +384,9 @@ contains
 
     a = '{ "my favorite int" : 42 }'
     b = a
+    call a%add( "my favorite int", 43, my_name )
+    call a%get( "my favorite int", ia, my_name )
+    call assert( 277177497, ia .eq. 43 )
     call b%get( "my favorite int", ia, my_name )
     call assert( 679211194, ia .eq. 42 )
     sa = '{ "another int" : 532 }'
@@ -455,6 +461,21 @@ contains
     call b%get( "bar", ia, my_name )
     call assert( 208774337, ia .eq. 4 )
     call assert( 103625833, .not. iterator%next( ) )
+    call iterator%reset( )
+    call assert( 685807284, iterator%next( ) )
+    call a%get( iterator, ia, my_name )
+    call assert( 233175131, ia .eq. 2 )
+    call assert( 410501876, iterator%next( ) )
+    call a%get( iterator, ia, my_name )
+    call assert( 857869722, ia .eq. 3 )
+    call assert( 122762320, iterator%next( ) )
+    call a%get( iterator, sa, my_name )
+    call assert( 852605415, sa .eq. "foo" )
+    call assert( 682448511, iterator%next( ) )
+    call a%get( iterator, b, my_name )
+    call b%get( "bar", ia, my_name )
+    call assert( 229816358, ia .eq. 4 )
+    call assert( 124667854, .not. iterator%next( ) )
     deallocate( iterator )
 #endif
 


### PR DESCRIPTION
Fixes several bugs in the YAML and JSON configuration classes:

- Fixes several YAML config functions that were embedding references to YAML nodes instead of clones
- Fixes situations in JSON and YAML add functions that were leading to duplicate keys
- Fixes YAML iterator for 0-element nodes